### PR TITLE
Collect custom steps used in --custom-step

### DIFF
--- a/Create.cs
+++ b/Create.cs
@@ -165,6 +165,10 @@ namespace illinkrepro
                         reproArgs.Add(searchDirectory with { Path = CopyDirectoryToInput(searchDirectory.Path) });
                         break;
 
+                    case ILLink.CustomStep customStep:
+                        reproArgs.Add(customStep with { Path = CopyFileToInput(customStep.Path) });
+                        break;
+
                     default:
                         reproArgs.Add(arg);
                         break;


### PR DESCRIPTION
This collects the custom linker step .dlls used as input to the linker. Unfortunately it doesn't work out of the box because ILLink doesn't accept relative paths in `--custom-step` parameter (https://github.com/dotnet/runtime/blob/07819e95b5d3536e266a60d8c06a4feab000194b/src/tools/illink/src/linker/Linker/Driver.cs#L880). I'm not sure how to proceed with it.